### PR TITLE
queQuery analysis data fixes

### DIFF
--- a/src/queryAnalysis/config/queryConfigs.go
+++ b/src/queryAnalysis/config/queryConfigs.go
@@ -299,14 +299,14 @@ TopPlans AS (
         qs.query_plan_hash AS query_plan_id,
         LEFT(st.text, @TextTruncateLimit) AS sql_text,
         qs.execution_count as execution_count,
-        (qs.total_elapsed_time / qs.execution_count) / 1000 AS avg_elapsed_time_ms,
+        COALESCE((qs.total_elapsed_time / NULLIF(qs.execution_count, 0)) / 1000, 0) AS avg_elapsed_time_ms,
         qp.query_plan
     FROM sys.dm_exec_query_stats AS qs
     CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
     CROSS APPLY sys.dm_exec_query_plan(qs.plan_handle) AS qp
     WHERE CONVERT(NVARCHAR(50), qs.query_hash) = @QueryID 
     AND qs.last_execution_time BETWEEN DATEADD(SECOND, -@IntervalSeconds, GETDATE()) AND GETDATE() 
-    AND (qs.total_elapsed_time / qs.execution_count) / 1000 > @ElapsedTimeThreshold
+    AND COALESCE((qs.total_elapsed_time / NULLIF(qs.execution_count, 0)) / 1000, 0) > @ElapsedTimeThreshold
     ORDER BY avg_elapsed_time_ms DESC
 ),
 PlanNodes AS (
@@ -317,19 +317,19 @@ PlanNodes AS (
         tp.query_plan_id,
         tp.avg_elapsed_time_ms,
         tp.execution_count,
-        n.value('(@NodeId)[1]', 'INT') AS NodeId,
-        n.value('(@PhysicalOp)[1]', 'VARCHAR(50)') AS PhysicalOp,
-        n.value('(@LogicalOp)[1]', 'VARCHAR(50)') AS LogicalOp,
-        n.value('(@EstimateRows)[1]', 'FLOAT') AS EstimateRows,
-        n.value('(@EstimateIO)[1]', 'FLOAT') AS EstimateIO,
-        n.value('(@EstimateCPU)[1]', 'FLOAT') AS EstimateCPU,
-        n.value('(@AvgRowSize)[1]', 'FLOAT') AS AvgRowSize,
-        n.value('(@EstimatedExecutionMode)[1]', 'VARCHAR(50)') AS EstimatedExecutionMode,
-        n.value('(@EstimatedTotalSubtreeCost)[1]', 'FLOAT') AS TotalSubtreeCost,
-        n.value('(@EstimatedOperatorCost)[1]', 'FLOAT') AS EstimatedOperatorCost,
-        n.value('(MemoryGrantInfo/@GrantedMemoryKb)[1]', 'INT') AS GrantedMemoryKb,
-        n.value('(Warnings/Warning/@SpillOccurred)[1]', 'BIT') AS SpillOccurred,
-        n.value('(Warnings/Warning/@NoJoinPredicate)[1]', 'BIT') AS NoJoinPredicate
+        COALESCE(n.value('(@NodeId)[1]', 'INT'), 0) AS NodeId,
+        COALESCE(n.value('(@PhysicalOp)[1]', 'VARCHAR(50)'), 'N/A') AS PhysicalOp,
+        COALESCE(n.value('(@LogicalOp)[1]', 'VARCHAR(50)'), 'N/A') AS LogicalOp,
+        COALESCE(n.value('(@EstimateRows)[1]', 'FLOAT'), 0.0) AS EstimateRows,
+        COALESCE(n.value('(@EstimateIO)[1]', 'FLOAT'), 0.0) AS EstimateIO,
+        COALESCE(n.value('(@EstimateCPU)[1]', 'FLOAT'), 0.0) AS EstimateCPU,
+        COALESCE(n.value('(@AvgRowSize)[1]', 'FLOAT'), 0.0) AS AvgRowSize,
+        COALESCE(n.value('(@EstimatedExecutionMode)[1]', 'VARCHAR(50)'), 'N/A') AS EstimatedExecutionMode,
+        COALESCE(n.value('(@EstimatedTotalSubtreeCost)[1]', 'FLOAT'), 0.0) AS TotalSubtreeCost,
+        COALESCE(n.value('(@EstimatedOperatorCost)[1]', 'FLOAT'), 0.0) AS EstimatedOperatorCost,
+        COALESCE(n.value('(MemoryGrantInfo/@GrantedMemoryKb)[1]', 'INT'), 0) AS GrantedMemoryKb,
+        COALESCE(n.value('(Warnings/Warning/@SpillOccurred)[1]', 'BIT'), 0) AS SpillOccurred,
+        COALESCE(n.value('(Warnings/Warning/@NoJoinPredicate)[1]', 'BIT'), 0) AS NoJoinPredicate
     FROM TopPlans AS tp
     CROSS APPLY tp.query_plan.nodes('//RelOp') AS RelOps(n)
 )


### PR DESCRIPTION
In case of null values in any of the columns in the exectutionPlan results. Show some default value in a valid format like 0 or 0.0 depending on the type of field.