### PR TITLE
handle max values for individual and group query count

### DIFF
--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -30,7 +30,7 @@ type ArgumentList struct {
 	EnableDiskMetricsInBytes     bool   `default:"true" help:"Enable collection of instance.diskInBytes."`
 	EnableQueryPerformance       bool   `default:"false"`
 	QueryResponseTimeThreshold   int    `default:"0"`
-	QueryCountThreshold          int    `default:"10"`
+	QueryCountThreshold          int    `default:"20"`
 	FetchInterval                int    `default:"15"`
 }
 

--- a/src/queryAnalysis/config/queryConfigs.go
+++ b/src/queryAnalysis/config/queryConfigs.go
@@ -339,3 +339,8 @@ ORDER BY plan_handle, NodeId;
 `
 
 var TextTruncateLimit = 4094
+
+var QueryResponseTimeThresholdDefault = 0
+var SlowQueryCountThresholdDefault = 20
+var IndividualQueryCountMax = 10
+var GroupedQueryCountMax = 30

--- a/src/queryAnalysis/query_analysis.go
+++ b/src/queryAnalysis/query_analysis.go
@@ -27,6 +27,8 @@ func QueryPerformanceMain(integration *integration.Integration, arguments args.A
 		return
 	}
 
+	utils.ValidateAndSetDefaults(&arguments)
+
 	var retryMechanism retrymechanism.RetryMechanism = &retrymechanism.RetryMechanismImpl{}
 
 	queryDetails, err := utils.LoadQueries(arguments)

--- a/src/queryAnalysis/utils/utils.go
+++ b/src/queryAnalysis/utils/utils.go
@@ -228,7 +228,7 @@ func ValidateAndSetDefaults(args *args.ArgumentList) {
 
 	if args.QueryCountThreshold < 0 {
 		args.QueryCountThreshold = config.SlowQueryCountThresholdDefault
-	} else if args.QueryCountThreshold >= 30 {
+	} else if args.QueryCountThreshold >= config.GroupedQueryCountMax {
 		args.QueryCountThreshold = config.GroupedQueryCountMax
 	}
 }


### PR DESCRIPTION
Handle the following conditions for the arguments taken by the user:
- Value below 0 will be changes to defaults(0 for reponseTime, 20 for groupedSlowQueryCount)
- If the number for groupedSlowQueryCount is more than what we plan to support, we will default it to 30
- At max 10 individualQuery will be fetched for executionPlan